### PR TITLE
Make functions returned "real" actions.

### DIFF
--- a/addon/-private/internals.js
+++ b/addon/-private/internals.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+const ClosureActionModule = Ember.__loader.require('ember-routing-htmlbars/keywords/closure-action');
+
+export const ACTION = ClosureActionModule.ACTION;

--- a/addon/helpers/route-action.js
+++ b/addon/helpers/route-action.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import getOwner from 'ember-getowner-polyfill';
+import { ACTION } from '../-private/internals';
 
 const {
   A: emberArray,
@@ -37,12 +38,16 @@ export default Helper.extend({
     let router = get(this, 'router');
     assert('[ember-route-action-helper] Unable to lookup router', router);
 
-    return function(...invocationArgs) {
+    let action = function(...invocationArgs) {
       let args = params.concat(invocationArgs);
       let { action, handler } = getRouteWithAction(router, actionName);
       assert(`[ember-route-action-helper] Unable to find action ${actionName}`, handler);
 
       return action.apply(handler, args);
     };
+
+    action[ACTION] = true;
+
+    return action;
   }
 });

--- a/addon/helpers/route-action.js
+++ b/addon/helpers/route-action.js
@@ -8,7 +8,8 @@ const {
   assert,
   computed,
   typeOf,
-  get
+  get,
+  run
 } = Ember;
 
 function getRoutes(router) {
@@ -43,7 +44,7 @@ export default Helper.extend({
       let { action, handler } = getRouteWithAction(router, actionName);
       assert(`[ember-route-action-helper] Unable to find action ${actionName}`, handler);
 
-      return action.apply(handler, args);
+      return run.join(handler, action, ...args);
     };
 
     action[ACTION] = true;

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -1,5 +1,9 @@
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+const { Route, Component } = Ember;
 
 moduleForAcceptance('Acceptance | main');
 
@@ -28,3 +32,24 @@ test('it has a return value', function(assert) {
   andThen(() => assert.equal(findWithAssert('.thing-show .max-value').text().trim(), '300'));
 });
 
+test('it can be used without rewrapping with (action (route-action "foo"))', function(assert) {
+  this.register('route:dynamic', Route.extend({
+    actions: {
+      foo() {
+        assert.ok(true, 'action was properly triggered on the route');
+      }
+    }
+  }));
+
+  this.register('template:dynamic', hbs`{{parent-component go=(route-action 'foo') }}`);
+  this.register('template:components/parent-component', hbs`{{child-component go=go}}`);
+  this.register('template:components/child-component', hbs`<button class="do-it">GO!</button>`);
+  this.register('component:child-component', Component.extend({
+    click() {
+      this.attrs.go();
+    }
+  }));
+
+  visit('/dynamic');
+  click('.do-it');
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,7 @@ Router.map(function() {
   this.route('thing', function() {
     this.route('show');
   });
+  this.route('dynamic');
 });
 
 export default Router;

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -10,6 +10,13 @@ export default function(name, options = {}) {
       if (options.beforeEach) {
         options.beforeEach.apply(this, arguments);
       }
+
+      this.register = (fullName, Factory) => {
+        let instance = this.application.__deprecatedInstance__;
+        let registry = instance.register ? instance : instance.registry;
+
+        return registry.register(fullName, Factory);
+      };
     },
 
     afterEach() {


### PR DESCRIPTION
This prevents the extra/double mutable object wrapping when passing down from one layer to the next (and avoids requiring extra `(action` wrapping to prevent this).

Given the following:

```hbs
{{! app/templates/route-template.hbs }}

{{parent-component go=(route-action 'foo')}}
```

```hbs
{{! app/templates/components/parent-component.hbs }}

{{child-component go=go}}
```

Prior to this change, `child-component` would get a mutable object in `this.attrs.go` instead of the invokable function (to work around this you would have to continue to wrap with `(action` either via `{{child-component go=(action go)}}` or `{{parent-component go=(action (route-action 'foo'))}}`).

After this change, `this.attrs.go()` Just Works™.