### PR TITLE
Fix `register` for 1.13.13 - 2.1 apps

### DIFF
--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -7,8 +7,11 @@ export default function(name, options = {}) {
     beforeEach() {
       this.application = startApp();
 
-      if (options.beforeEach) {
-        options.beforeEach.apply(this, arguments);
+      // BugFix: Can be removed after 2.1.  If resolver is set then fallback doesn't happen properly
+      // for more information: https://github.com/emberjs/ember.js/commit/e3ad9e2772e066459ddb3af78be45d9a6003f5ce
+      var legacyRegistry = this.application.__deprecatedInstance__.registry;
+      if (legacyRegistry) {
+        legacyRegistry.resolver = function noOpResolverBugFix() {};
       }
 
       this.register = (fullName, Factory) => {
@@ -17,6 +20,10 @@ export default function(name, options = {}) {
 
         return registry.register(fullName, Factory);
       };
+
+      if (options.beforeEach) {
+        options.beforeEach.apply(this, arguments);
+      }
     },
 
     afterEach() {


### PR DESCRIPTION
Also moved the register function above the call to `beforeEach` so you can register in a tests `beforeEach` if necessary.