### PR TITLE
Add ember-alpha to try config.

### DIFF
--- a/addon/-private/internals.js
+++ b/addon/-private/internals.js
@@ -4,8 +4,10 @@ let ClosureActionModule;
 
 if ('ember-htmlbars/keywords/closure-action' in Ember.__loader.registry) {
   ClosureActionModule = Ember.__loader.require('ember-htmlbars/keywords/closure-action');
-} else {
+} else if ('ember-routing-htmlbars/keywords/closure-action' in Ember.__loader.registry) {
   ClosureActionModule = Ember.__loader.require('ember-routing-htmlbars/keywords/closure-action');
+} else {
+  ClosureActionModule = { };
 }
 
 export const ACTION = ClosureActionModule.ACTION;

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -105,6 +105,17 @@ module.exports = {
           'ember': 'canary'
         }
       }
+    },
+    {
+      name: 'ember-alpha',
+      bower: {
+        dependencies: {
+          'ember': 'alpha'
+        },
+        resolutions: {
+          'ember': 'alpha'
+        }
+      }
     }
   ]
 };

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -46,7 +46,7 @@ test('it can be used without rewrapping with (action (route-action "foo"))', fun
   this.register('template:components/child-component', hbs`<button class="do-it">GO!</button>`);
   this.register('component:child-component', Component.extend({
     click() {
-      this.attrs.go();
+      this.get('go')();
     }
   }));
 


### PR DESCRIPTION
Tests are passing (with the tweak to avoid using `this.attrs` in the acceptance test). 

I have reported the issue that passing an action through a middle layer doesn't properly prevent mut-wrapping in `this.attrs` as was done in HTMLBars with a failing test in https://github.com/emberjs/ember.js/pull/13996.  