### PR TITLE
Fail immediately if route action is missing

### DIFF
--- a/addon/helpers/route-action.js
+++ b/addon/helpers/route-action.js
@@ -39,16 +39,16 @@ export default Helper.extend({
     let router = get(this, 'router');
     assert('[ember-route-action-helper] Unable to lookup router', router);
 
-    let action = function(...invocationArgs) {
-      let args = params.concat(invocationArgs);
-      let { action, handler } = getRouteWithAction(router, actionName);
-      assert(`[ember-route-action-helper] Unable to find action ${actionName}`, handler);
+    let { action, handler } = getRouteWithAction(router, actionName);
+    assert(`[ember-route-action-helper] Unable to find action ${actionName}`, handler);
 
+    let routeAction = function(...invocationArgs) {
+      let args = params.concat(invocationArgs);
       return run.join(handler, action, ...args);
     };
 
-    action[ACTION] = true;
+    routeAction[ACTION] = true;
 
-    return action;
+    return routeAction;
   }
 });

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -54,3 +54,14 @@ test('it can be used without rewrapping with (action (route-action "foo"))', fun
   visit('/dynamic');
   click('.do-it');
 });
+
+test('it should throw an error if the route action is missing', function(assert) {
+  this.register('route:dynamic', Route);
+  this.register('template:dynamic', hbs`{{test-component go=(route-action 'doesNotExist')}}`);
+  this.register('template:components/test-component', hbs`welp`);
+
+  visit('/dynamic').catch(err => {
+    const msg = 'Assertion Failed: [ember-route-action-helper] Unable to find action doesNotExist';
+    assert.equal(err.message, msg);
+  });
+});

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -59,6 +59,6 @@ test('it can be used without rewrapping with (action (route-action "foo"))', fun
 test('it should throw an error immediately if the route action is missing', function(assert) {
   visit('/dynamic2');
 
-  const msg = 'Assertion Failed: [ember-route-action-helper] Unable to find action notAnAction';
-  andThen().catch(err => assert.equal(err.message, msg));
+  let expectedResult = 'Assertion Failed: [ember-route-action-helper] Unable to find action notAnAction';
+  andThen().catch(({ message }) => assert.equal(message, expectedResult));
 });

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -15,6 +15,7 @@ moduleForAcceptance('Acceptance | main', {
       }
     }));
     this.application.register('template:dynamic', hbs`{{parent-component go=(route-action 'foo') }}`);
+    this.application.register('template:dynamic2', hbs`{{parent-component go=(route-action 'notAnAction')}}`);
     this.application.register('template:components/parent-component', hbs`{{child-component go=go}}`);
     this.application.register('template:components/child-component', hbs`<button class="do-it">GO!</button>`);
     this.application.register('component:child-component', Component.extend({
@@ -55,13 +56,10 @@ test('it can be used without rewrapping with (action (route-action "foo"))', fun
   click('.do-it');
 });
 
-test('it should throw an error if the route action is missing', function(assert) {
-  this.register('route:dynamic', Route);
-  this.register('template:dynamic', hbs`{{test-component go=(route-action 'doesNotExist')}}`);
-  this.register('template:components/test-component', hbs`welp`);
+test('it should throw an error immediately if the route action is missing', function(assert) {
+  const promise = visit('/dynamic2');
 
-  visit('/dynamic').catch(err => {
-    const msg = 'Assertion Failed: [ember-route-action-helper] Unable to find action doesNotExist';
-    assert.equal(err.message, msg);
-  });
+  assert.expect(1);
+  const msg = 'Assertion Failed: [ember-route-action-helper] Unable to find action notAnAction';
+  promise.then(() => {}, err => assert.equal(err.message, msg));
 });

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -57,9 +57,8 @@ test('it can be used without rewrapping with (action (route-action "foo"))', fun
 });
 
 test('it should throw an error immediately if the route action is missing', function(assert) {
-  const promise = visit('/dynamic2');
+  visit('/dynamic2');
 
-  assert.expect(1);
   const msg = 'Assertion Failed: [ember-route-action-helper] Unable to find action notAnAction';
-  promise.then(() => {}, err => assert.equal(err.message, msg));
+  andThen().catch(err => assert.equal(err.message, msg));
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
     this.route('show');
   });
   this.route('dynamic');
+  this.route('dynamic2');
 });
 
 export default Router;


### PR DESCRIPTION
Hello! I noticed today that this PR was never merged. For reference, the issue was https://github.com/DockYard/ember-route-action-helper/issues/21.