### PR TITLE
Fix deprecation warning in Ember 2.13

### DIFF
--- a/addon/helpers/route-action.js
+++ b/addon/helpers/route-action.js
@@ -13,8 +13,14 @@ const {
   runInDebug
 } = Ember;
 
+function getCurrentHandlerInfos(router) {
+  let routerLib = router._routerMicrolib || router.router;
+
+  return routerLib.currentHandlerInfos;
+}
+
 function getRoutes(router) {
-  return emberArray(router.router.currentHandlerInfos)
+  return emberArray(getCurrentHandlerInfos(router))
     .mapBy('handler')
     .reverse();
 }


### PR DESCRIPTION
See http://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib