### PR TITLE
Use native `typeof` instead

### DIFF
--- a/addon/helpers/route-action.js
+++ b/addon/helpers/route-action.js
@@ -6,7 +6,6 @@ const {
   Helper,
   assert,
   computed,
-  typeOf,
   get,
   getOwner,
   run,
@@ -31,7 +30,7 @@ function getRouteWithAction(router, actionName) {
     let actions = route.actions || route._actions;
     action = actions[actionName];
 
-    return typeOf(action) === 'function';
+    return typeof(action) === 'function';
   });
 
   return { action, handler };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,7 +3,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    // Add options here
+    'ember-cli-babel': { includePolyfill: true }
   });
 
   /*

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -14,8 +14,16 @@ moduleForAcceptance('Acceptance | main', {
         }
       }
     }));
+    this.application.register('route:dynamic3', Route.extend({
+      actions: {
+        async bar() {
+          assert.ok(true, 'async functions are found');
+        }
+      }
+    }));
     this.application.register('template:dynamic', hbs`{{parent-component go=(route-action 'foo') }}`);
     this.application.register('template:dynamic2', hbs`{{parent-component go=(route-action 'notAnAction')}}`);
+    this.application.register('template:dynamic3', hbs`{{parent-component go=(route-action 'bar')}}`);
     this.application.register('template:components/parent-component', hbs`{{child-component go=go}}`);
     this.application.register('template:components/child-component', hbs`<button class="do-it">GO!</button>`);
     this.application.register('component:child-component', Component.extend({
@@ -51,8 +59,15 @@ test('it has a return value', function(assert) {
   andThen(() => assert.equal(findWithAssert('.thing-show .max-value').text().trim(), '300'));
 });
 
-test('it can be used without rewrapping with (action (route-action "foo"))', function() {
+test('it can be used without rewrapping with (action (route-action "foo"))', function(assert) {
+  assert.expect(1);
   visit('/dynamic');
+  click('.do-it');
+});
+
+test('it works with async functions', function(assert) {
+  assert.expect(1);
+  visit('/dynamic3');
   click('.do-it');
 });
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -13,6 +13,7 @@ Router.map(function() {
   });
   this.route('dynamic');
   this.route('dynamic2');
+  this.route('dynamic3');
 });
 
 export default Router;


### PR DESCRIPTION
Closes #55

This is going away in `3.0.0` but I think it's worth releasing in the current major