### PR TITLE
bump ember-getowner-polyfill version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^6.3.0",
-    "ember-getowner-polyfill": "^1.1.1"
+    "ember-getowner-polyfill": "^2.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
satisfies dependency linting errors:

```
        message: >
            Expected only one version of ember-getowner-polyfill, but found
            dustbunny
            ├─┬ checkout
            │ └─┬ ember-css-modules
            │   └── ember-getowner-polyfill@2.0.1
            ├─┬ ember-concurrency
            │ └── ember-getowner-polyfill@1.2.5
            ├─┬ ember-css-modules
            │ └── ember-getowner-polyfill@2.0.1
            └─┬ ember-route-action-helper
              └── ember-getowner-polyfill@1.2.5
```

https://github.com/machty/ember-concurrency/pull/173

cc @cibernox 