### PR TITLE
Fix deprecation warning in Ember 2.13 (#53)

### DIFF
--- a/addon/helpers/route-action.js
+++ b/addon/helpers/route-action.js
@@ -12,8 +12,14 @@ const {
   run
 } = Ember;
 
+function getCurrentHandlerInfos(router) {
+  let routerLib = router._routerMicrolib || router.router;
+
+  return routerLib.currentHandlerInfos;
+}
+
 function getRoutes(router) {
-  return emberArray(router.router.currentHandlerInfos)
+  return emberArray(getCurrentHandlerInfos(router))
     .mapBy('handler')
     .reverse();
 }


### PR DESCRIPTION
(cherry picked from commit 6b77abe32d90e337f34c3abf61113dbd895afbc5)

I'm stuck on v1.0.0, but need this commit to support newer versions of EmberJS.

https://github.com/DockYard/ember-route-action-helper/issues/41#issuecomment-249970797

Ideally, creating a v1.1.0 tag

edit: will reopen if necessary 