### PR TITLE
Use of _routerMicrolib.currentRouteInfos if available

### DIFF
--- a/addon/helpers/route-action.js
+++ b/addon/helpers/route-action.js
@@ -6,15 +6,19 @@ import { run } from '@ember/runloop';
 import { runInDebug, assert } from '@ember/debug';
 import { ACTION } from '../-private/internals';
 
-function getCurrentHandlerInfos(router) {
+function getCurrentInfos(router) {
   let routerLib = router._routerMicrolib || router.router;
 
-  return routerLib.currentHandlerInfos;
+  return {
+    currentInfos: routerLib.currentRouteInfos || routerLib.currentHandlerInfos,
+    mapBy: routerLib.currentRouteInfos && 'route' || 'handler'
+  }
 }
 
 function getRoutes(router) {
-  return emberArray(getCurrentHandlerInfos(router))
-    .mapBy('handler')
+  const { currentInfos, mapBy } = getCurrentInfos(router);
+  return emberArray(currentInfos)
+    .mapBy(mapBy)
     .reverse();
 }
 


### PR DESCRIPTION
Because _routerMicrolib.currentHandlerInfos private API is deprecated