### PR TITLE
exclude ember-try packages from npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,8 @@
 bower.json
 ember-cli-build.js
 testem.js
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/package.json.ember-try


### PR DESCRIPTION
The current published version includes these files which brings the package size to 127 megabytes